### PR TITLE
Fix: move domain interfaces

### DIFF
--- a/src/main/java/com/example/psp/domain/repositories/transaction/TransactionRepository.java
+++ b/src/main/java/com/example/psp/domain/repositories/transaction/TransactionRepository.java
@@ -1,9 +1,0 @@
-package com.example.psp.domain.repositories.transaction;
-
-import com.example.psp.domain.entities.Transaction;
-
-public interface TransactionRepository {
-
-    void save(Transaction transaction);
-    void update(Transaction transaction);
-}

--- a/src/main/java/com/example/psp/domain/services/acquirer/AcquirerRouter.java
+++ b/src/main/java/com/example/psp/domain/services/acquirer/AcquirerRouter.java
@@ -1,8 +1,0 @@
-package com.example.psp.domain.services.acquirer;
-
-import com.example.psp.domain.valueobjects.CardDetails;
-
-public interface AcquirerRouter {
-
-    Acquirer getAcquirer(CardDetails cardDetails);
-}

--- a/src/main/java/com/example/psp/domain/services/transaction/TransactionService.java
+++ b/src/main/java/com/example/psp/domain/services/transaction/TransactionService.java
@@ -1,8 +1,0 @@
-package com.example.psp.domain.services.transaction;
-
-import com.example.psp.domain.entities.Transaction;
-
-public interface TransactionService {
-
-    PaymentResponse processPayment(PaymentRequest paymentDetails);
-}

--- a/src/main/java/com/example/psp/repository/transaction/TransactionRepository.java
+++ b/src/main/java/com/example/psp/repository/transaction/TransactionRepository.java
@@ -1,0 +1,10 @@
+package com.example.psp.repository.transaction;
+
+import com.example.psp.domain.entities.Transaction;
+import reactor.core.publisher.Mono;
+
+public interface TransactionRepository {
+
+    Mono<Transaction> save(Transaction transaction);
+    Mono<Transaction> update(Transaction transaction);
+}

--- a/src/main/java/com/example/psp/service/acquirer/ports/Acquirer.java
+++ b/src/main/java/com/example/psp/service/acquirer/ports/Acquirer.java
@@ -1,13 +1,14 @@
-package com.example.psp.domain.services.acquirer;
+package com.example.psp.service.acquirer.ports;
 
 import com.example.psp.domain.enums.AcquirerDecision;
 import com.example.psp.domain.enums.AcquirerType;
 import com.example.psp.domain.valueobjects.CardDetails;
 import com.example.psp.domain.valueobjects.Money;
+import reactor.core.publisher.Mono;
 
 public interface Acquirer {
 
-    AcquirerDecision authorizeTransaction(CardDetails cardDetails, Money money);
+    Mono<AcquirerDecision> authorizeTransaction(CardDetails cardDetails, Money money);
 
     AcquirerType getType();
 

--- a/src/main/java/com/example/psp/service/acquirer/ports/AcquirerRouter.java
+++ b/src/main/java/com/example/psp/service/acquirer/ports/AcquirerRouter.java
@@ -1,0 +1,9 @@
+package com.example.psp.service.acquirer.ports;
+
+import com.example.psp.domain.valueobjects.CardDetails;
+import reactor.core.publisher.Mono;
+
+public interface AcquirerRouter {
+
+    Mono<Acquirer> getAcquirer(CardDetails cardDetails);
+}

--- a/src/main/java/com/example/psp/service/transaction/ports/PaymentRequest.java
+++ b/src/main/java/com/example/psp/service/transaction/ports/PaymentRequest.java
@@ -1,4 +1,4 @@
-package com.example.psp.domain.services.transaction;
+package com.example.psp.service.transaction.ports;
 
 import com.example.psp.domain.valueobjects.CardDetails;
 import com.example.psp.domain.valueobjects.Money;

--- a/src/main/java/com/example/psp/service/transaction/ports/PaymentResponse.java
+++ b/src/main/java/com/example/psp/service/transaction/ports/PaymentResponse.java
@@ -1,4 +1,4 @@
-package com.example.psp.domain.services.transaction;
+package com.example.psp.service.transaction.ports;
 
 import com.example.psp.domain.enums.TransactionStatus;
 import lombok.Builder;

--- a/src/main/java/com/example/psp/service/transaction/ports/TransactionService.java
+++ b/src/main/java/com/example/psp/service/transaction/ports/TransactionService.java
@@ -1,0 +1,8 @@
+package com.example.psp.service.transaction.ports;
+
+import reactor.core.publisher.Mono;
+
+public interface TransactionService {
+
+    Mono<PaymentResponse> processPayment(PaymentRequest paymentDetails);
+}


### PR DESCRIPTION
fix(domain): move domain interfaces to upper layers
- Service layer
  - Acquirer, AcquirerRouter moved to service.acquirer.ports
  - TransactionService, PaymentRequest, PaymentResponse moved to service.transaction.ports
  - Output of Acquirer, AcquirerRouter, TransactionService methods wrapped in Mono<>
- Repository layer
  - TransactionRepository moved to repository.transaction
  - Output of TransactionRepository methods wrapped in Mono<>